### PR TITLE
fix: remove self from siblings

### DIFF
--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -77,7 +77,8 @@ export function traverse(
 			if (data && Object.keys(data).length) return data;
 			if (!hydrate) return []; // skip this file
 			const breadcrumb = path.split(/[/\\]/).reverse();
-			return hydrate({ breadcrumb, buffer, parse, siblings: tree });
+			const siblings = tree.filter(({ path: leaf }) => leaf !== path);
+			return hydrate({ breadcrumb, buffer, parse, siblings });
 		} else if (level !== 0) {
 			const depth = level < 0 ? level : level - 1;
 			const options = { entry: path, depth, compile: fn };

--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -53,7 +53,9 @@ export function traverse(
 	const backpack = tree.flatMap(({ type, breadcrumb, buffer }) => {
 		const path = [...breadcrumb].reverse().join('/');
 		if (type === 'file' && files(path)) {
-      const siblings = tree.filter(({ path: leaf }) => leaf !== path);
+			const siblings = tree.filter(
+				({ breadcrumb }) => [...breadcrumb].reverse().join('/') !== path,
+			);
 			return hydrate({ breadcrumb, buffer, marker, parse, siblings }) ?? [];
 		} else if (level !== 0) {
 			const depth = level < 0 ? level : level - 1;

--- a/workspace/marqua/src/types.d.ts
+++ b/workspace/marqua/src/types.d.ts
@@ -10,7 +10,6 @@ export interface HydrateChunk {
 	breadcrumb: string[];
 	buffer: Buffer;
 	parse: typeof parse;
-	// TODO: remove self from siblings
 	siblings: Array<
 		| { type: 'file'; name: string; path: string; buffer: Buffer }
 		| { type: 'directory'; name: string; path: string; buffer: undefined }


### PR DESCRIPTION
As the name implies, it should only contain all the items in the tree except itself, or just their _siblings_.