### PR TITLE
feat: change `compile` option to `files`

### DIFF
--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -72,9 +72,7 @@ export function traverse(
 	});
 
 	const backpack = tree.flatMap(({ type, path, buffer }) => {
-		if (!files(path)) return [];
-
-		if (type === 'file') {
+		if (type === 'file' && files(path)) {
 			const breadcrumb = path.split(/[/\\]/).reverse();
 			return hydrate({ breadcrumb, buffer, marker, parse, siblings: tree });
 		} else if (level !== 0) {

--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -23,7 +23,7 @@ export function compile(entry, hydrate) {
 				}
 				return { type: 'file', name, path, buffer };
 			});
-			return hydrate({ breadcrumb, buffer, parse, siblings: tree });
+			return hydrate({ breadcrumb, buffer, marker, parse, siblings: tree });
 		}
 		const { content, metadata } = parse(buffer.toString('utf-8'));
 		return { ...metadata, content };
@@ -47,7 +47,7 @@ export function compile(entry, hydrate) {
  * @template [Transformed = Array<Output & import('../types.js').Metadata>]
  *
  * @param {Options} options
- * @param {(chunk: import('../types.js').HydrateChunk) => undefined | Output} [hydrate]
+ * @param {(chunk: import('../types.js').HydrateChunk) => undefined | Output} hydrate
  * @param {(items: Array<Output & import('../types.js').Metadata>) => Transformed} [transform]
  * @returns {Transformed}
  */
@@ -76,7 +76,7 @@ export function traverse(
 
 		if (type === 'file') {
 			const breadcrumb = path.split(/[/\\]/).reverse();
-			return hydrate({ breadcrumb, buffer, parse, siblings: tree });
+			return hydrate({ breadcrumb, buffer, marker, parse, siblings: tree });
 		} else if (level !== 0) {
 			const depth = level < 0 ? level : level - 1;
 			return traverse({ entry: path, depth, files }, hydrate);

--- a/workspace/marqua/src/types.d.ts
+++ b/workspace/marqua/src/types.d.ts
@@ -1,3 +1,4 @@
+import type { marker } from './artisan/index.js';
 import type { parse } from './core/index.js';
 
 type Primitives = string | boolean | null;
@@ -9,6 +10,7 @@ export interface FrontMatter {
 export interface HydrateChunk {
 	breadcrumb: string[];
 	buffer: Buffer;
+	marker: typeof marker;
 	parse: typeof parse;
 	// TODO: remove self from siblings
 	siblings: Array<

--- a/workspace/marqua/test/apps/multiple/index.spec.js
+++ b/workspace/marqua/test/apps/multiple/index.spec.js
@@ -25,7 +25,7 @@ basics.standard('standard traversal', () => {
 
 basics.depth('depth traversal', () => {
 	const output = traverse(
-		{ entry: `${target}/depth/input`, depth: 2 },
+		{ entry: `${target}/depth/input`, depth: 1 },
 		({ buffer, marker, parse }) => {
 			const { content, metadata } = parse(buffer.toString('utf-8'));
 			return { ...metadata, content: marker.render(content) };

--- a/workspace/marqua/test/apps/multiple/index.spec.js
+++ b/workspace/marqua/test/apps/multiple/index.spec.js
@@ -11,7 +11,10 @@ const basics = {
 const target = `${process.cwd()}/test/apps/multiple`;
 
 basics.standard('standard traversal', () => {
-	const output = traverse({ entry: `${target}/standard/input` });
+	const output = traverse({ entry: `${target}/standard/input` }, ({ buffer, marker, parse }) => {
+		const { content, metadata } = parse(buffer.toString('utf-8'));
+		return { ...metadata, content: marker.render(content) };
+	});
 	const expected = readJSON(`${target}/standard/expected.json`);
 
 	assert.type(output, 'object');
@@ -21,7 +24,13 @@ basics.standard('standard traversal', () => {
 });
 
 basics.depth('depth traversal', () => {
-	const output = traverse({ entry: `${target}/depth/input`, depth: 1 });
+	const output = traverse(
+		{ entry: `${target}/depth/input`, depth: 2 },
+		({ buffer, marker, parse }) => {
+			const { content, metadata } = parse(buffer.toString('utf-8'));
+			return { ...metadata, content: marker.render(content) };
+		},
+	);
 	const expected = readJSON(`${target}/depth/expected.json`);
 
 	assert.type(output, 'object');

--- a/workspace/marqua/test/apps/utils.js
+++ b/workspace/marqua/test/apps/utils.js
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+/** @param {string} pathname  */
 export function readJSON(pathname) {
 	if (path.sep !== '/') pathname = pathname.replace(/\//g, path.sep);
 	return JSON.parse(fs.readFileSync(pathname, 'utf-8'));

--- a/workspace/marqua/tsconfig.json
+++ b/workspace/marqua/tsconfig.json
@@ -4,6 +4,6 @@
 		"target": "ES2019",
 		"noEmit": true
 	},
-	"include": ["src/**/*"],
+	"include": ["src/**/*", "test/**/*"],
 	"exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
This PR introduces a new option to `traverse` called `files`, which replaces `compile` option, that filters the files in the directory tree and executes the `hydrate` function, which is now a required parameter.

The `HydrateChunk` also receives `marker` as a new passthrough argument for convenience and full control of the renderer.

---

The `compile` option in `traverse` is confusing and hard to differentiate between the `compile` function that is exported. It also checks if it returns true for a `path` and.. calls compile with the same `hydrate`? To make it even more confusing, it checks if the returned data is truthy, else it will.. executes `hydrate` again (what)?

Okay, the first one which passes it to the `compile` function wants the `content` to be rendered to HTML. The `!hydrate` checking also kind of makes sense in a way that we just want to _compile_ a markdown file and get its content, but in that case it's better to just call the `compile` function directly without passing in `hydrate`. For cases where we want to compile all the markdown files in a or multiple directories, we can do them with `buffer` + `parse` and now `marker.render`

```ts
import { compile, traverse } from 'marqua/fs';

const data = traverse('content', ({ buffer, marker, parse }) => {
  const { content, metadata } = parse(buffer.toString('utf-8'));
  return { ...metadata, content: marker.render(content) };
});
```