### PR TITLE
feat: replace `name` & `path` with `breadcrumb`

### DIFF
--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -40,18 +40,19 @@ export function traverse(
 	/** @type {import('../types.js').HydrateChunk['siblings']} */
 	const tree = fs.readdirSync(entry).map((name) => {
 		const path = join(entry, name);
-		const breadcrumb = path.split(/[/\\]/).reverse();
-		if (fs.lstatSync(path).isDirectory()) {
-			return { type: 'directory', breadcrumb };
-		}
-		const buffer = fs.readFileSync(path);
-		return { type: 'file', breadcrumb, buffer };
+		return {
+			/** @type {any} - discriminated union without multiple returns */
+			type: fs.lstatSync(path).isDirectory() ? 'directory' : 'file',
+			breadcrumb: path.split(/[/\\]/).reverse(),
+			get buffer() {
+				return this.type === 'file' ? fs.readFileSync(path) : void 0;
+			},
+		};
 	});
 
 	const backpack = tree.flatMap(({ type, breadcrumb, buffer }) => {
 		const path = [...breadcrumb].reverse().join('/');
 		if (type === 'file' && files(path)) {
-			const breadcrumb = path.split(/[/\\]/).reverse();
 			return hydrate({ breadcrumb, buffer, marker, parse, siblings: tree }) ?? [];
 		} else if (level !== 0) {
 			const depth = level < 0 ? level : level - 1;

--- a/workspace/marqua/src/types.d.ts
+++ b/workspace/marqua/src/types.d.ts
@@ -12,8 +12,8 @@ export interface HydrateChunk {
 	parse: typeof parse;
 	// TODO: remove self from siblings
 	siblings: Array<
-		| { type: 'file'; name: string; path: string; buffer: Buffer }
-		| { type: 'directory'; name: string; path: string; buffer: undefined }
+		| { type: 'file'; breadcrumb: string[]; buffer: Buffer }
+		| { type: 'directory'; breadcrumb: string[]; buffer: undefined }
 	>;
 }
 


### PR DESCRIPTION
Removed both `name` and `path` from the `siblings` parameters and adds `breadcrumb` that works the same way as the one in `hydrate` callback signature.