### PR TITLE
feat: deconflict with context-sensitive headings

### DIFF
--- a/workspace/marqua/src/artisan/marker.js
+++ b/workspace/marqua/src/artisan/marker.js
@@ -35,7 +35,8 @@ marker.renderer.rules.heading_open = scope(() => {
 		if (level === 2) parents = [id];
 		if (level === 3) parents = [parents[0], id];
 		if (level === 4) parents[2] = id;
-		return `<${token.tag} id="${parents.join('-')}">`;
+		const uid = parents.filter((p) => p).join('-');
+		return `<${token.tag} id="${uid}">`;
 	};
 });
 /** @type {typeof marker['renderer']['rules']['image']} */

--- a/workspace/marqua/src/artisan/marker.js
+++ b/workspace/marqua/src/artisan/marker.js
@@ -1,4 +1,5 @@
 import MarkIt from 'markdown-it';
+import { scope } from 'mauss';
 import { generate } from '../utils.js';
 import { transform } from './brush.js';
 
@@ -21,13 +22,22 @@ export const marker = MarkIt({
 
 // Renderer Override Rules
 /** @type {typeof marker['renderer']['rules']['html_block']} */
-marker.renderer.rules.heading_open = (tokens, idx) => {
-	const [token, text] = [tokens[idx], tokens[idx + 1].content];
-	if (+token.tag.slice(-1) > 3) return `<${token.tag}>`;
-	const [delimited] = text.match(/\$\(.*\)/) || [''];
-	const id = generate.id(delimited.slice(2, -1) || text);
-	return `<${token.tag} id="${id}">`;
-};
+marker.renderer.rules.heading_open = scope(() => {
+	let parents = ['', ''];
+
+	return (tokens, idx) => {
+		const [token, text] = [tokens[idx], tokens[idx + 1].content];
+		const level = +token.tag.slice(-1);
+		if (level > 4) return `<${token.tag}>`;
+		const [delimited] = text.match(/\$\(.*\)/) || [''];
+		const id = generate.id(delimited.slice(2, -1) || text);
+
+		if (level === 2) parents = [id];
+		if (level === 3) parents = [parents[0], id];
+		if (level === 4) parents[2] = id;
+		return `<${token.tag} id="${parents.join('-')}">`;
+	};
+});
 /** @type {typeof marker['renderer']['rules']['image']} */
 marker.renderer.rules.image = (tokens, idx, options, env, self) => {
 	const token = tokens[idx];

--- a/workspace/marqua/src/core/index.js
+++ b/workspace/marqua/src/core/index.js
@@ -33,14 +33,23 @@ export function parse(source) {
 					const match = line.trim().match(/^(#{2,4}) (.+)/);
 					if (!match) continue;
 
-					const [, h, title] = match;
+					const [, hashes, title] = match;
 					const [delimited] = title.match(/\$\(.*\)/) || [''];
 
 					table.push({
 						id: generate.id(delimited.slice(2, -1) || title),
 						title: title.replace(delimited, delimited.slice(2, -1)),
-						level: h.length,
+						level: hashes.length,
 					});
+				}
+
+				let parents = ['', ''];
+				for (let i = 0; i < table.length; i++) {
+					const { id, level } = table[i];
+					if (level === 2) parents = [id];
+					if (level === 3) parents = [parents[0], id];
+					if (level === 4) parents[2] = id;
+					table[i].id = parents.join('-');
 				}
 
 				return table;

--- a/workspace/marqua/src/core/index.js
+++ b/workspace/marqua/src/core/index.js
@@ -49,7 +49,7 @@ export function parse(source) {
 					if (level === 2) parents = [id];
 					if (level === 3) parents = [parents[0], id];
 					if (level === 4) parents[2] = id;
-					table[i].id = parents.join('-');
+					table[i].id = parents.filter((p) => p).join('-');
 				}
 
 				return table;

--- a/workspace/marqua/src/core/index.spec.js
+++ b/workspace/marqua/src/core/index.spec.js
@@ -311,45 +311,43 @@ simple contents
 
 story and plot
 
-### subsection of story and plot
+### sub-story
 
-subsection contents
+sub-story contents
 
 #### smallest heading
 
 something here
 
-### second subsection
+### sub-plot
 		`.trim(),
 	);
 
-	assert.equal(metadata.table, [
-		{
-			id: 'simple-heading',
-			level: 2,
-			title: 'simple heading',
-		},
-		{
-			id: 'story-plot',
-			level: 2,
-			title: 'story & plot',
-		},
-		{
-			id: 'subsection-of-story-and-plot',
-			level: 3,
-			title: 'subsection of story and plot',
-		},
-		{
-			id: 'smallest-heading',
-			level: 4,
-			title: 'smallest heading',
-		},
-		{
-			id: 'second-subsection',
-			level: 3,
-			title: 'second subsection',
-		},
-	]);
+	assert.equal(metadata.table[0], {
+		id: 'simple-heading',
+		level: 2,
+		title: 'simple heading',
+	});
+	assert.equal(metadata.table[1], {
+		id: 'story-plot',
+		level: 2,
+		title: 'story & plot',
+	});
+	assert.equal(metadata.table[2], {
+		id: 'story-plot-sub-story',
+		level: 3,
+		title: 'sub-story',
+	});
+	assert.equal(metadata.table[3], {
+		id: 'story-plot-sub-story-smallest-heading',
+		level: 4,
+		title: 'smallest heading',
+	});
+	assert.equal(metadata.table[4], {
+		id: 'story-plot-sub-plot',
+		level: 3,
+		title: 'sub-plot',
+	});
 });
 
 suites['parse/']('parse markdown contents', () => {


### PR DESCRIPTION
This will make heading ids unique by prepending the "parent(s)" heading id to the current one.

Closes #34 