### PR TITLE
feat: make `traverse` throw on nonexistent entry

### DIFF
--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -60,7 +60,7 @@ export function traverse(
 		return [];
 	});
 
-	return transform(/** @type {Array<Output & import('../types.js').Metadata>} */ (backpack));
+	return transform(/** @type {any} */ (backpack));
 }
 
 /**

--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -32,11 +32,6 @@ export function traverse(
 	hydrate,
 	transform = (v) => /** @type {Transformed} */ (v),
 ) {
-	if (!fs.existsSync(entry)) {
-		console.warn(`Skipping "${entry}", path does not exists`);
-		return transform([]);
-	}
-
 	/** @type {import('../types.js').HydrateChunk['siblings']} */
 	const tree = fs.readdirSync(entry).map((name) => {
 		const path = join(entry, name);


### PR DESCRIPTION
We want the function to throw so that users are aware that their entry point is nonexistent, it should never throw when called recursively as it is reading from the filesystem directly.