### PR TITLE
chore: rename `content` to `body`

### DIFF
--- a/workspace/marqua/src/core/index.js
+++ b/workspace/marqua/src/core/index.js
@@ -8,7 +8,7 @@ export function parse(source) {
 	const stuffed = inject(crude, memory);
 
 	return {
-		content: stuffed,
+		body: stuffed,
 		metadata: Object.assign(memory, {
 			/** estimated reading time */
 			get estimate() {

--- a/workspace/marqua/src/core/index.spec.js
+++ b/workspace/marqua/src/core/index.spec.js
@@ -353,7 +353,7 @@ something here
 });
 
 suites['parse/']('parse markdown contents', () => {
-	const { content, metadata } = core.parse(
+	const { body, metadata } = core.parse(
 		`
 ---
 title: Hello Parser
@@ -369,7 +369,7 @@ Welcome to the contents
 		table: [],
 	});
 
-	assert.equal(content.trim(), 'Welcome to the contents');
+	assert.equal(body.trim(), 'Welcome to the contents');
 });
 
 Object.values(suites).forEach((v) => v.run());

--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -8,8 +8,8 @@ import { parse } from '../core/index.js';
  * @returns {Output & import('../types.js').Metadata & { content: string }}
  */
 export function compile(entry) {
-	const { content, metadata } = parse(fs.readFileSync(entry, 'utf-8'));
-	const result = { ...metadata, content: marker.render(content) };
+	const { body, metadata } = parse(fs.readFileSync(entry, 'utf-8'));
+	const result = { ...metadata, content: marker.render(body) };
 	return /** @type {any} */ (result);
 }
 

--- a/workspace/marqua/test/apps/multiple/index.spec.js
+++ b/workspace/marqua/test/apps/multiple/index.spec.js
@@ -12,8 +12,8 @@ const target = `${process.cwd()}/test/apps/multiple`;
 
 basics.standard('standard traversal', () => {
 	const output = traverse({ entry: `${target}/standard/input` }, ({ buffer, marker, parse }) => {
-		const { content, metadata } = parse(buffer.toString('utf-8'));
-		return { ...metadata, content: marker.render(content) };
+		const { body, metadata } = parse(buffer.toString('utf-8'));
+		return { ...metadata, content: marker.render(body) };
 	});
 	const expected = readJSON(`${target}/standard/expected.json`);
 
@@ -27,8 +27,8 @@ basics.depth('depth traversal', () => {
 	const output = traverse(
 		{ entry: `${target}/depth/input`, depth: 1 },
 		({ buffer, marker, parse }) => {
-			const { content, metadata } = parse(buffer.toString('utf-8'));
-			return { ...metadata, content: marker.render(content) };
+			const { body, metadata } = parse(buffer.toString('utf-8'));
+			return { ...metadata, content: marker.render(body) };
 		},
 	);
 	const expected = readJSON(`${target}/depth/expected.json`);

--- a/workspace/website/src/routes/+page.server.ts
+++ b/workspace/website/src/routes/+page.server.ts
@@ -10,8 +10,8 @@ export const load: import('./$types').PageServerLoad = async () => {
 		({ breadcrumb: [filename], buffer, marker, parse }) => {
 			const path = `workspace/content/${filename}`;
 			const slug = filename.match(/^(\d{2})-(.+).md$/)![2];
-			const { content, metadata } = parse(buffer.toString('utf-8'));
-			return { slug, title: metadata.title, path, content: marker.render(content) };
+			const { body, metadata } = parse(buffer.toString('utf-8'));
+			return { slug, title: metadata.title, path, content: marker.render(body) };
 		},
 	);
 


### PR DESCRIPTION
The old returned `content` from the fs module function makes it seem like it's a special property that will be rendered. Now that `marker` is passed as one of the arguments of `hydrate`, users can call `marker.render` on anything by themselves and it feels more appropriate to indicate that the returned content from `parse` is the raw untransformed version — its body.