### PR TITLE
breaking: drop node v14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Follow this if you're looking to contribute to the code.
 
 ### Preparing
 
-First step is to prepare your environment and make sure that [pnpm](https://pnpm.io/) is available to use, you can follow their [installation guide](https://pnpm.io/installation), but if you're using Node.js above v16.13, you can simply enable [corepack](https://nodejs.org/api/corepack.html).
+First step is to prepare your environment and make sure that [pnpm](https://pnpm.io/) is available to use, you can follow their [installation guide](https://pnpm.io/installation) or enable them through [corepack](https://nodejs.org/api/corepack.html).
 
 ```bash
 corepack enable

--- a/workspace/marqua/package.json
+++ b/workspace/marqua/package.json
@@ -49,7 +49,7 @@
 		"index.d.ts.map"
 	],
 	"engines": {
-		"node": ">=14.8"
+		"node": ">=16.13"
 	},
 	"prettier": "mauss/prettier.json",
 	"keywords": [


### PR DESCRIPTION
Node v14 have been EOL since 30 April 2023 (https://endoflife.date/nodejs)