### PR TITLE
feat: simplify transform module

### DIFF
--- a/workspace/aubade/src/transform/index.js
+++ b/workspace/aubade/src/transform/index.js
@@ -4,14 +4,14 @@ export { pipe } from 'mauss';
 
 /**
  * @template {{ slug?: string; title?: any }} T
+ * @param {T[]} items
  * @param {{
  * 	base?: string
  * 	breakpoint?(next: T): boolean
  * 	sort?(x: T, y: T): number
  * }} options
- * @returns
  */
-export function chain(options) {
+export function chain(items, options) {
 	const { base = '', breakpoint, sort } = options;
 
 	/**
@@ -20,27 +20,24 @@ export function chain(options) {
 	 * @typedef {{ flank?: Flank }} Attachment
 	 */
 
-	/** @type {(items: T[]) => Array<T & Attachment>} */
-	return (items) => {
-		if (sort) items = items.sort(sort);
-		const array = /** @type {Array<T & Attachment>} */ (items);
-		const unwrap = ntv.pick(['slug', 'title']);
-		for (let idx = 0; idx < array.length; idx++) {
-			const [back, next] = [array[idx - 1], array[idx + 1]];
-			if (back) {
-				const unwrapped = unwrap(back);
-				unwrapped.slug = base + unwrapped.slug;
-				array[idx].flank = { back: unwrapped };
-			}
-			if (breakpoint && breakpoint(next)) return array;
-			if (next) {
-				if (!array[idx].flank) array[idx].flank = {};
-				const unwrapped = unwrap(next);
-				unwrapped.slug = base + unwrapped.slug;
-				// @ts-expect-error - `flank` definitely exists
-				array[idx].flank.next = unwrapped;
-			}
+	if (sort) items = items.sort(sort);
+	const array = /** @type {Array<T & Attachment>} */ (items);
+	const unwrap = ntv.pick(['slug', 'title']);
+	for (let idx = 0; idx < array.length; idx++) {
+		const [back, next] = [array[idx - 1], array[idx + 1]];
+		if (back) {
+			const unwrapped = unwrap(back);
+			unwrapped.slug = base + unwrapped.slug;
+			array[idx].flank = { back: unwrapped };
 		}
-		return array;
-	};
+		if (breakpoint && breakpoint(next)) return array;
+		if (next) {
+			if (!array[idx].flank) array[idx].flank = {};
+			const unwrapped = unwrap(next);
+			unwrapped.slug = base + unwrapped.slug;
+			// @ts-expect-error - `flank` definitely exists
+			array[idx].flank.next = unwrapped;
+		}
+	}
+	return array;
 }

--- a/workspace/content/10-modules.md
+++ b/workspace/content/10-modules.md
@@ -261,25 +261,16 @@ traverse('path/to/content').hydrate(() => {}, pipe(/* ... */));
 The `chain` transformer is used to add a `flank` property to each items and attaches the previous (`idx - 1`) and the item after (`idx + 1`) as `flank: { back, next }`, be sure to sort it the way you intend it to be before running this transformer.
 
 ```typescript
-export function chain<T extends { slug?: string; title?: any }>(options: {
-	base?: string;
-	breakpoint?: (next: T) => boolean;
-	sort?: (x: T, y: T) => number;
-}): (items: T[]) => Array<T & Attachment>;
+export function chain<T extends { slug?: string; title?: any }>(
+	items: T[],
+	options: {
+		base?: string;
+		breakpoint?: (next: T) => boolean;
+		sort?: (x: T, y: T) => number;
+	},
+): Array<T & Attachment>;
 ```
 
 -   A `base` string can be passed as a prefix in the `slug` property of each items.
 -   A `breakpoint` function can be passed to stop the chain on a certain condition.
-
-    ```typescript
-    traverse('path/to/content').hydrate(
-    	({}) => {},
-    	chain({
-    		breakpoint(item) {
-    			return; // ...
-    		},
-    	}),
-    );
-    ```
-
 -   A `sort` function can be passed to sort the items before chaining them.

--- a/workspace/website/src/lib/content/index.ts
+++ b/workspace/website/src/lib/content/index.ts
@@ -25,9 +25,7 @@ export const DATA = {
 					content: marker.render(content),
 				};
 			},
-			chain({
-				base: '/docs/',
-			}),
+			(items) => chain(items, { base: '/docs/' }),
 		);
 	},
 };


### PR DESCRIPTION
This allows the transform module to be used standalone and doesn't lose type-safety. Previously, it needed to be passed as the second argument of `hydrate` to be able to correctly infer the item's signature.