### PR TITLE
breaking: rename `mrq` to `aubade`

### DIFF
--- a/workspace/aubade/src/artisan/palette/index.ts
+++ b/workspace/aubade/src/artisan/palette/index.ts
@@ -33,29 +33,28 @@ export function transform(source: string, dataset: Dataset): string {
 		([k, v]) => `data-${k.toLowerCase().replace(/[^a-z\-]/g, '')}="${escape(v || '')}"`,
 	);
 
-	// @TODO: rename `data-mrq` to `data-aubade`
 	// needs to be /^<pre/ to prevent added wrapper from markdown-it
-	return `<pre data-mrq="block" class="mrq">
+	return `<pre data-aubade="block">
 	<header
-		data-mrq="header"
+		data-aubade="header"
 		${attrs.join('\n\t\t')}
-		class="mrq ${file ? '' : 'empty'}"
+		class="aubade ${file ? '' : 'empty'}"
 	>${file ? `<span>${file}</span>` : ''}
-		<div data-mrq="toolbar" class="mrq">
+		<div data-aubade="toolbar">
 			${icon('list', 'Toggle\nNumbering')}
 			${icon('clipboard', 'Copy')}
 		</div>
 	</header>
 
 	<div
-		data-mrq="pre"
+		data-aubade="pre"
 		${attrs.join('\n\t\t')}
-		class="mrq language-${rest.language || 'none'}"
+		class="aubade language-${rest.language || 'none'}"
 	>${highlighted.trim()}</div>
 </pre>`;
 }
 
 function icon(name: 'clipboard' | 'list', tooltip: string) {
-	const span = `<span data-mrq="tooltip" class="mrq">${tooltip}</span>`;
-	return `<button data-mrq-toolbar="${name}" class="mrq">${span}</button>`;
+	const span = `<span data-aubade="tooltip">${tooltip}</span>`;
+	return `<button data-aubade-toolbar="${name}">${span}</button>`;
 }

--- a/workspace/aubade/styles/code.css
+++ b/workspace/aubade/styles/code.css
@@ -2,33 +2,32 @@
 	--font-default: 'Karla Variable', 'Karla', system-ui, sans-serif;
 	--font-monospace: 'Fira Code Variable', 'Fira Code', 'Inconsolata', monospace;
 
-	--mrq-tab-size: 2;
-	--mrq-rounding: 0.3rem;
+	--aubade-tab-size: 2;
+	--aubade-rounding: 0.3rem;
 
-	--mrq-primary: #0070bb;
-	--mrq-bg-dark: #2d2d2d;
-	--mrq-bg-light: #f7f7f7;
-	--mrq-cl-dark: #242424;
-	--mrq-cl-light: #dadada;
+	--aubade-primary: #0070bb;
+	--aubade-background: #2d2d2d;
+	--aubade-overlay: #f7f7f7;
+	--aubade-text: #dadada;
 }
 
-.mrq[data-mrq='block'],
-.mrq[data-mrq='header'],
-.mrq[data-mrq='pre'] {
+[data-aubade='block'],
+[data-aubade='header'],
+[data-aubade='pre'] {
 	width: 100%;
 	position: relative;
-	tab-size: var(--mrq-tab-size);
+	tab-size: var(--aubade-tab-size);
 
-	--mrq-pre-bg: #525252;
-	--mrq-bounce: 10rem;
-	--mrq-tms: 100ms;
-	--mrq-tfn: cubic-bezier(0.6, -0.28, 0.735, 0.045);
+	--aubade-header: #525252;
+	--aubade-bounce: 4rem;
+	--aubade-transition: 150ms;
+	--aubade-function: cubic-bezier(0.6, -0.28, 0.735, 0.045);
 }
-.mrq[data-mrq='block'] {
+[data-aubade='block'] {
 	white-space: normal;
 	margin-top: 1rem;
 }
-.mrq[data-mrq='pre'] {
+[data-aubade='pre'] {
 	white-space: pre;
 }
 code {
@@ -36,43 +35,43 @@ code {
 	top: -0.075rem;
 	padding: 0.15rem 0.3rem;
 	margin: 0 0.1rem;
-	border-radius: var(--mrq-rounding);
-	background: var(--mrq-bg-dark);
-	color: var(--mrq-cl-light);
+	border-radius: var(--aubade-rounding);
+	background: var(--aubade-background);
+	color: var(--aubade-text);
 	line-height: 1.5;
 	font-size: 0.8em; /* em - relative to wrapper */
 	white-space: nowrap;
 }
 
-/* ---- <div data-mrq="pre"> ---- */
+/* ---- <div data-aubade="pre"> ---- */
 
-.mrq[data-mrq='pre'] {
+[data-aubade='pre'] {
 	overflow-x: auto;
 	overflow-y: hidden;
 	padding: 1.8rem 1rem 1rem 1.6rem;
-	border-bottom-left-radius: var(--mrq-rounding);
-	border-bottom-right-radius: var(--mrq-rounding);
-	background: var(--mrq-bg-dark);
-	color: var(--mrq-cl-light);
+	border-bottom-left-radius: var(--aubade-rounding);
+	border-bottom-right-radius: var(--aubade-rounding);
+	background: var(--aubade-background);
+	color: var(--aubade-text);
 	font-family: var(--font-monospace);
 }
-.mrq[data-mrq='pre'] code {
+[data-aubade='pre'] code {
 	top: 0;
 	padding: 0;
 	margin: 0;
 	border-radius: 0;
 	white-space: pre;
 }
-.mrq[data-mrq='pre'],
-.mrq[data-mrq='pre'] code {
+[data-aubade='pre'],
+[data-aubade='pre'] code {
 	line-height: 1.5;
 	font-size: 0.85rem;
 }
 
-.mrq[data-mrq='pre'].numbered {
+[data-aubade='pre'].numbered {
 	padding-left: 0.6rem;
 }
-.mrq[data-mrq='pre'].numbered code::before {
+[data-aubade='pre'].numbered code::before {
 	content: attr(data-line);
 	max-width: 2rem;
 	width: 100%;
@@ -84,50 +83,50 @@ code {
 }
 
 /* header check */
-.mrq[data-mrq='header'].empty + .mrq[data-mrq='pre'] {
+[data-aubade='header'].empty + [data-aubade='pre'] {
 	padding-top: 2rem;
 }
-.mrq[data-mrq='header'][data-language='']:not(.empty) + .mrq[data-mrq='pre'] {
+[data-aubade='header'][data-language='']:not(.empty) + [data-aubade='pre'] {
 	padding-top: 1rem;
 }
-.mrq[data-mrq='header'].empty + .mrq[data-mrq='pre'] {
-	border-top-right-radius: var(--mrq-rounding);
-	border-top-left-radius: var(--mrq-rounding);
+[data-aubade='header'].empty + [data-aubade='pre'] {
+	border-top-right-radius: var(--aubade-rounding);
+	border-top-left-radius: var(--aubade-rounding);
 }
 
-/* ---- <header data-mrq="header"> ---- */
+/* ---- <header data-aubade="header"> ---- */
 
-.mrq[data-mrq='header'] {
+[data-aubade='header'] {
 	padding: 0.5rem 1rem;
 	margin: 0;
-	border-top-right-radius: var(--mrq-rounding);
-	border-top-left-radius: var(--mrq-rounding);
-	background-color: var(--mrq-pre-bg);
+	border-top-right-radius: var(--aubade-rounding);
+	border-top-left-radius: var(--aubade-rounding);
+	background-color: var(--aubade-header);
 	color: #fff;
 	font-weight: 300;
 	font-family: var(--font-monospace);
 	font-size: clamp(0.8rem, 2vw, 0.95rem);
 }
-.mrq[data-mrq='header'].empty {
+[data-aubade='header'].empty {
 	padding: 0;
 	background: transparent;
 }
-.mrq[data-mrq='header'].empty::after {
+[data-aubade='header'].empty::after {
 	top: 0;
-	border-top-right-radius: var(--mrq-rounding);
+	border-top-right-radius: var(--aubade-rounding);
 }
-.mrq[data-mrq='header']::after,
-.mrq[data-mrq='header']::before {
+[data-aubade='header']::after,
+[data-aubade='header']::before {
 	font-family: var(--font-default);
 	font-size: 0.75rem;
 }
-.mrq[data-mrq='header'] > span {
+[data-aubade='header'] > span {
 	overflow: hidden;
 	width: 100%;
 	display: inline-flex;
 }
 /* language coloured line */
-.mrq[data-mrq='header']::before {
+[data-aubade='header']::before {
 	content: '';
 	z-index: 1;
 	height: 0.4rem;
@@ -136,34 +135,34 @@ code {
 	left: 0;
 	right: 0;
 
-	transition: var(--mrq-tms);
-	transition-timing-function: var(--mrq-tfn);
+	transition: var(--aubade-transition);
+	transition-timing-function: var(--aubade-function);
 }
-.mrq[data-mrq='header'].empty::before {
+[data-aubade='header'].empty::before {
 	height: 0.6rem;
 	top: 0;
-	border-top-left-radius: var(--mrq-rounding);
-	border-top-right-radius: var(--mrq-rounding);
+	border-top-left-radius: var(--aubade-rounding);
+	border-top-right-radius: var(--aubade-rounding);
 }
 
-.mrq[data-mrq='block']:focus-within > .mrq[data-mrq='header']::before,
-.mrq[data-mrq='block']:hover > .mrq[data-mrq='header']::before {
-	right: var(--mrq-bounce);
-	transition: var(--mrq-tms);
+[data-aubade='block']:focus-within > [data-aubade='header']::before,
+[data-aubade='block']:hover > [data-aubade='header']::before {
+	right: var(--aubade-bounce);
+	transition: var(--aubade-transition);
 }
-.mrq[data-mrq='block']:focus-within > .mrq[data-mrq='header'].empty[data-language='']::before,
-.mrq[data-mrq='block']:hover > .mrq[data-mrq='header'].empty[data-language='']::before {
+[data-aubade='block']:focus-within > [data-aubade='header'].empty[data-language='']::before,
+[data-aubade='block']:hover > [data-aubade='header'].empty[data-language='']::before {
 	right: 0;
 }
 
 /* ---- data-language ---- */
 
-.mrq[data-mrq='header'] {
-	--mrq-header-dark: #323330;
-	--mrq-header-light: #feefe8;
+[data-aubade='header'] {
+	--aubade-header-dark: #323330;
+	--aubade-header-light: #feefe8;
 }
 
-.mrq[data-mrq='header']::after {
+[data-aubade='header']::after {
 	z-index: 1;
 	position: absolute;
 	top: 100%;
@@ -174,166 +173,166 @@ code {
 	letter-spacing: 0.1rem;
 	text-transform: uppercase;
 	border-bottom-left-radius: 2px;
-	transition: var(--mrq-tms);
-	transition-timing-function: var(--mrq-tfn);
+	transition: var(--aubade-transition);
+	transition-timing-function: var(--aubade-function);
 }
-.mrq[data-mrq='header'][data-language]::after {
+[data-aubade='header'][data-language]::after {
 	content: attr(data-language);
 }
-.mrq[data-mrq='block']:focus-within > .mrq[data-mrq='header']::after,
-.mrq[data-mrq='block']:hover > .mrq[data-mrq='header']::after {
-	right: var(--mrq-bounce);
-	border-bottom-right-radius: var(--mrq-rounding);
-	border-bottom-left-radius: var(--mrq-rounding);
-	transition: var(--mrq-tms);
+[data-aubade='block']:focus-within > [data-aubade='header']::after,
+[data-aubade='block']:hover > [data-aubade='header']::after {
+	right: var(--aubade-bounce);
+	border-bottom-right-radius: var(--aubade-rounding);
+	border-bottom-left-radius: var(--aubade-rounding);
+	transition: var(--aubade-transition);
 }
-.mrq[data-mrq='header'][data-language='']:not(.empty)::after,
-.mrq[data-mrq='header'][data-language='']:not(.empty)::before {
+[data-aubade='header'][data-language='']:not(.empty)::after,
+[data-aubade='header'][data-language='']:not(.empty)::before {
 	content: none;
 }
-.mrq[data-mrq='header'][data-language='']::before {
-	background: var(--mrq-pre-bg);
+[data-aubade='header'][data-language='']::before {
+	background: var(--aubade-header);
 }
 
 /* Language Styles */
-.mrq[data-mrq='header'][data-language='bash']::after,
-.mrq[data-mrq='header'][data-language='bash']::before {
+[data-aubade='header'][data-language='bash']::after,
+[data-aubade='header'][data-language='bash']::before {
 	background: #363377;
 	color: #a2a0d6;
 }
-.mrq[data-mrq='header'][data-language='css']::after,
-.mrq[data-mrq='header'][data-language='css']::before {
+[data-aubade='header'][data-language='css']::after,
+[data-aubade='header'][data-language='css']::before {
 	background: #264de4;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
-.mrq[data-mrq='header'][data-language='htaccess']::after,
-.mrq[data-mrq='header'][data-language='htaccess']::before {
+[data-aubade='header'][data-language='htaccess']::after,
+[data-aubade='header'][data-language='htaccess']::before {
 	background: #8bc34a;
-	color: var(--mrq-header-dark);
+	color: var(--aubade-header-dark);
 }
-.mrq[data-mrq='header'][data-language='html']::after,
-.mrq[data-mrq='header'][data-language='html']::before {
+[data-aubade='header'][data-language='html']::after,
+[data-aubade='header'][data-language='html']::before {
 	background: #e34f26;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
-.mrq[data-mrq='header'][data-language='java']::after,
-.mrq[data-mrq='header'][data-language='java']::before {
+[data-aubade='header'][data-language='java']::after,
+[data-aubade='header'][data-language='java']::before {
 	background: #f89820;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
-.mrq[data-mrq='header'][data-language='javascript']::after,
-.mrq[data-mrq='header'][data-language='javascript']::before,
-.mrq[data-mrq='header'][data-language='json']::after,
-.mrq[data-mrq='header'][data-language='json']::before,
-.mrq[data-mrq='header'][data-language='js']::after,
-.mrq[data-mrq='header'][data-language='js']::before {
+[data-aubade='header'][data-language='javascript']::after,
+[data-aubade='header'][data-language='javascript']::before,
+[data-aubade='header'][data-language='json']::after,
+[data-aubade='header'][data-language='json']::before,
+[data-aubade='header'][data-language='js']::after,
+[data-aubade='header'][data-language='js']::before {
 	background: #f0db4f;
-	color: var(--mrq-header-dark);
+	color: var(--aubade-header-dark);
 }
-.mrq[data-mrq='header'][data-language='markdown']::after,
-.mrq[data-mrq='header'][data-language='markdown']::before,
-.mrq[data-mrq='header'][data-language='md']::after,
-.mrq[data-mrq='header'][data-language='md']::before {
+[data-aubade='header'][data-language='markdown']::after,
+[data-aubade='header'][data-language='markdown']::before,
+[data-aubade='header'][data-language='md']::after,
+[data-aubade='header'][data-language='md']::before {
 	background: #083fa1;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
-.mrq[data-mrq='header'][data-language='python']::after,
-.mrq[data-mrq='header'][data-language='python']::before {
+[data-aubade='header'][data-language='python']::after,
+[data-aubade='header'][data-language='python']::before {
 	background: #dddddd;
-	color: var(--mrq-header-dark);
+	color: var(--aubade-header-dark);
 }
-.mrq[data-mrq='header'][data-language='shell']::after,
-.mrq[data-mrq='header'][data-language='shell']::before {
+[data-aubade='header'][data-language='shell']::after,
+[data-aubade='header'][data-language='shell']::before {
 	background: #f3e2bb;
 	color: #c09022;
 }
-.mrq[data-mrq='header'][data-language='svelte']::after,
-.mrq[data-mrq='header'][data-language='svelte']::before {
+[data-aubade='header'][data-language='svelte']::after,
+[data-aubade='header'][data-language='svelte']::before {
 	background: #ff3e00;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
-.mrq[data-mrq='header'][data-language='terminal']::after,
-.mrq[data-mrq='header'][data-language='terminal']::before {
+[data-aubade='header'][data-language='terminal']::after,
+[data-aubade='header'][data-language='terminal']::before {
 	background: #dddddd;
-	color: var(--mrq-header-dark);
+	color: var(--aubade-header-dark);
 }
-.mrq[data-mrq='header'][data-language='typescript']::after,
-.mrq[data-mrq='header'][data-language='typescript']::before,
-.mrq[data-mrq='header'][data-language='ts']::after,
-.mrq[data-mrq='header'][data-language='ts']::before {
+[data-aubade='header'][data-language='typescript']::after,
+[data-aubade='header'][data-language='typescript']::before,
+[data-aubade='header'][data-language='ts']::after,
+[data-aubade='header'][data-language='ts']::before {
 	background: #3178c6;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
-.mrq[data-mrq='header'][data-language='yaml']::after,
-.mrq[data-mrq='header'][data-language='yaml']::before {
+[data-aubade='header'][data-language='yaml']::after,
+[data-aubade='header'][data-language='yaml']::before {
 	background: #000000;
-	color: var(--mrq-header-light);
+	color: var(--aubade-header-light);
 }
 
-/* ---- <div data-mrq="toolbar"> ---- */
+/* ---- <div data-aubade="toolbar"> ---- */
 
-.mrq[data-mrq='toolbar'] {
+[data-aubade='toolbar'] {
 	z-index: 2;
 	opacity: 0;
 	position: absolute;
-	top: 50%;
-	right: 0.2rem;
+	top: 0;
+	right: 0.25rem;
 	display: grid;
-	gap: 0.2rem;
+	gap: 0.25rem;
 	grid-auto-flow: column;
-	transition: var(--mrq-tms);
+	transition: var(--aubade-transition);
 	transform: translateY(-50%);
 }
 
-.mrq[data-mrq='header'].empty .mrq[data-mrq='toolbar'] {
+[data-aubade='header'].empty [data-aubade='toolbar'] {
 	transform: translateY(50%);
 }
-.mrq[data-mrq='header'].empty:not([data-language='']) .mrq[data-mrq='toolbar'] {
+[data-aubade='header'].empty:not([data-language='']) [data-aubade='toolbar'] {
 	transform: translateY(10%);
 }
-.mrq[data-mrq='header']:not([data-language='']):not(.empty) .mrq[data-mrq='toolbar'] {
+[data-aubade='header']:not([data-language='']):not(.empty) [data-aubade='toolbar'] {
 	top: 100%;
 	transform: translateY(10%);
 }
 
-.mrq[data-mrq='block']:focus-within .mrq[data-mrq='toolbar'],
-.mrq[data-mrq='block']:hover .mrq[data-mrq='toolbar'] {
+[data-aubade='block']:focus-within [data-aubade='toolbar'],
+[data-aubade='block']:hover [data-aubade='toolbar'] {
 	opacity: 1;
 }
 
-.mrq[data-mrq='toolbar'] > .mrq[data-mrq-toolbar] {
+[data-aubade='toolbar'] > [data-aubade-toolbar] {
 	cursor: pointer;
-	width: 1.3rem;
-	height: 1.3rem;
+	width: 1.5rem;
+	height: 1.5rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	padding: 0.25rem;
 	border-radius: 50%;
-	color: var(--mrq-primary);
+	color: var(--aubade-primary);
 	text-align: center;
 	font-size: 0.7rem;
-	background-color: var(--mrq-bg-light);
+	background-color: var(--aubade-overlay);
 	background-size: contain;
 	background-repeat: no-repeat;
 	background-origin: content-box;
 }
 
-.mrq[data-mrq-toolbar]:focus {
+[data-aubade-toolbar]:focus {
 	outline: 1px solid rgba(255, 255, 255, 0.4);
 }
-.mrq[data-mrq-toolbar] > .mrq[data-mrq='tooltip'] {
+[data-aubade-toolbar] > [data-aubade='tooltip'] {
 	user-select: none;
 	position: absolute;
 	bottom: 2rem;
 	display: none;
 	padding: 0.3rem 0.6rem;
-	border-radius: calc(var(--mrq-rounding) * 2);
+	border-radius: calc(var(--aubade-rounding) * 2);
 	background-color: #7c7c7c;
 	color: #ffffff;
-	transition: var(--mrq-tms);
+	transition: var(--aubade-transition);
 }
-.mrq[data-mrq-toolbar] > .mrq[data-mrq='tooltip']::after {
+[data-aubade-toolbar] > [data-aubade='tooltip']::after {
 	content: '';
 	position: absolute;
 	bottom: 0;
@@ -344,15 +343,15 @@ code {
 	border-color: #7c7c7c transparent transparent transparent;
 	transform: translateY(99%);
 }
-.mrq[data-mrq-toolbar]:focus > .mrq[data-mrq='tooltip'],
-.mrq[data-mrq-toolbar]:hover > .mrq[data-mrq='tooltip'] {
+[data-aubade-toolbar]:focus > [data-aubade='tooltip'],
+[data-aubade-toolbar]:hover > [data-aubade='tooltip'] {
 	display: inline-flex;
 }
 
 /* toolbar icons */
-.mrq[data-mrq-toolbar='clipboard'] {
+[data-aubade-toolbar='clipboard'] {
 	background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%230070bb' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'%3E%3C/path%3E%3Crect x='8' y='2' width='8' height='4' rx='1' ry='1'%3E%3C/rect%3E%3C/svg%3E");
 }
-.mrq[data-mrq-toolbar='list'] {
+[data-aubade-toolbar='list'] {
 	background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%230070bb' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='8' y1='6' x2='21' y2='6'%3E%3C/line%3E%3Cline x1='8' y1='12' x2='21' y2='12'%3E%3C/line%3E%3Cline x1='8' y1='18' x2='21' y2='18'%3E%3C/line%3E%3Cline x1='3' y1='6' x2='3.01' y2='6'%3E%3C/line%3E%3Cline x1='3' y1='12' x2='3.01' y2='12'%3E%3C/line%3E%3Cline x1='3' y1='18' x2='3.01' y2='18'%3E%3C/line%3E%3C/svg%3E");
 }

--- a/workspace/website/src/app.css
+++ b/workspace/website/src/app.css
@@ -40,6 +40,7 @@
 
 html,
 body {
+	height: 100%;
 	background: var(--stone-900);
 	color: var(--stone-200);
 	font-family: var(--font-default);

--- a/workspace/website/src/app.d.ts
+++ b/workspace/website/src/app.d.ts
@@ -1,18 +1,23 @@
-/// <reference types="@sveltejs/kit" />
-/// <reference types="../../aubade" />
+declare global {
+	namespace App {
+		// interface Locals {}
 
-namespace App {
-	// interface Error {}
-	// interface Locals {}
-	interface PageData {
-		meta: {
-			title: string;
-			description?: string;
-			og?: {
+		interface PageData {
+			meta: {
 				title: string;
-				url?: string;
+				canonical: `/${string}`;
 				description?: string;
+				og?: {
+					title: string;
+					url?: string;
+					description?: string;
+					// TODO
+				};
 			};
-		};
+		}
+
+		// interface PageState {}
 	}
 }
+
+export {};

--- a/workspace/website/src/lib/Divider.svelte
+++ b/workspace/website/src/lib/Divider.svelte
@@ -13,7 +13,7 @@
 <style>
 	div {
 		padding: 0;
-		background: var(--mrq-primary);
+		background: var(--aubade-primary);
 	}
 	.horizontal {
 		width: 100%;

--- a/workspace/website/src/lib/Index.svelte
+++ b/workspace/website/src/lib/Index.svelte
@@ -24,7 +24,7 @@
 
 <style>
 	details {
-		--radius: calc(var(--mrq-rounding));
+		--radius: calc(var(--aubade-rounding));
 
 		z-index: 2;
 		position: sticky;

--- a/workspace/website/src/routes/+error.svelte
+++ b/workspace/website/src/routes/+error.svelte
@@ -2,20 +2,22 @@
 	import { page } from '$app/state';
 </script>
 
-<main>
+<div>
 	<h1>{page.status}</h1>
 	<h2>{page.error?.message}</h2>
 
-	<a href="/">Click here to get back to the home page</a>
-</main>
+	<a href="/docs/introduction">back to the docs</a>
+</div>
 
 <style>
-	main {
+	div {
+		height: 100%;
 		display: grid;
-		margin: 2rem auto;
+		align-content: center;
 		text-align: center;
 	}
 	h1 {
+		font-family: var(--font-monospace);
 		font-size: 5rem;
 	}
 	a {

--- a/workspace/website/src/routes/+layout.svelte
+++ b/workspace/website/src/routes/+layout.svelte
@@ -5,63 +5,67 @@
 	import 'aubade/styles/code.css';
 	import '../app.css';
 
-	import { page } from '$app/state';
+	import MetaHead from 'syv/core/MetaHead.svelte';
+	import Header from './Header.svelte';
+	import Footer from './Footer.svelte';
 
+	import { dev } from '$app/environment';
+	import { afterNavigate } from '$app/navigation';
+	import { page } from '$app/state';
 	const { children } = $props();
+
+	afterNavigate(() => {
+		// @ts-expect-error - update vercel insights more accurately
+		window.va?.('pageview', { route: page.route.id, url: page.url.pathname });
+	});
 </script>
 
-<svelte:head>
-	<title>{page.data.meta?.title || `Error ${page.status}`} • Aubade</title>
-	<meta name="author" content="ignatiusmb" />
+<MetaHead
+	domain="https://aubade.mauss.dev"
+	title="{page.data.meta?.title || page.status} • Aubade"
+	canonical={page.data.meta?.canonical || '/'}
+	description={page.data.meta?.description || 'filesystem-based content processor'}
+	authors={['Ignatius Bagus.']}
+	og={{
+		site_name: 'Aubade',
+		title: page.data.meta?.title || `${page.status}`,
+		description: page.data.meta?.description,
+	}}
+	scripts={{
+		'/_vercel/insights/script.js': !dev && { 'data-disable-auto-track': '1' },
+		'/_vercel/speed-insights/script.js': !dev && { 'data-route': page.route.id },
+	}}
+/>
 
-	{#if page.data.meta?.description}
-		<meta name="description" content={page.data.meta.description} />
+<main>
+	{#if !page.error}
+		<Header />
 	{/if}
 
-	<meta property="og:site_name" content="Aubade" />
-	<meta property="og:locale" content="en_ID" />
+	{@render children()}
 
-	{#if page.data.meta?.og}
-		{@const { title, url, description } = page.data.meta.og}
-		<meta property="og:title" content={title} />
-		<meta property="og:type" content="article" />
-		{#if url}
-			<meta property="og:url" content={url} />
-		{/if}
-		{#if description}
-			<meta property="og:description" content={description} />
-		{/if}
+	{#if !page.error}
+		<Footer />
 	{/if}
-</svelte:head>
-
-{@render children()}
-
-<footer>
-	<p>
-		<span>&Larr;</span>
-		<a href="https://github.com/ignatiusmb/aubade">Aubade</a>
-		<span style:color="var(--mrq-primary)">&#x2764;</span>
-		<a href="https://github.com/sveltejs/kit">SvelteKit</a>
-		<span>&Rarr;</span>
-	</p>
-	<p>
-		<span>&copy; 2019&ndash;{new Date().getFullYear()}</span>
-		<a href="https://mauss.dev">Ignatius Bagussuputra</a>
-	</p>
-</footer>
+</main>
 
 <style>
-	footer {
-		width: 100%;
-		max-width: 84ch;
-		position: relative;
-		display: grid;
-		gap: 0.5rem;
-		padding: 3rem 2rem;
-		margin: 0 auto;
+	main {
+		height: 100%;
 
-		text-align: center;
-		font-family: var(--font-monospace);
-		font-size: 0.875rem;
+		:global(i[data-icon]) {
+			width: 1.5rem;
+			height: 1.5rem;
+			display: inline-block;
+			background: currentColor;
+			mask: no-repeat center / 100%;
+			mask-image: var(--svg);
+
+			&[data-icon='copyright'] {
+				width: 1rem;
+				height: 1rem;
+				--svg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"><circle cx="128" cy="128" r="96"/><path d="M160,152a40,40,0,1,1,0-48"/></svg>');
+			}
+		}
 	}
 </style>

--- a/workspace/website/src/routes/+page.server.ts
+++ b/workspace/website/src/routes/+page.server.ts
@@ -2,11 +2,4 @@ import { redirect } from '@sveltejs/kit';
 
 export async function load() {
 	redirect(307, '/docs/introduction');
-
-	return {
-		meta: {
-			title: 'Data Authoring Framework',
-			description: 'A framework to manage your static content',
-		},
-	};
 }

--- a/workspace/website/src/routes/Footer.svelte
+++ b/workspace/website/src/routes/Footer.svelte
@@ -1,0 +1,39 @@
+<footer>
+	<small>
+		<span>&Larr;</span>
+		<span>from the</span>
+		<a href="https://mauss.dev/atelier#aubade">alkamauss atelier</a>
+		<span>&Rarr;</span>
+	</small>
+
+	<p>
+		<i data-icon="copyright"></i>
+		<span>2019&ndash;{new Date().getFullYear()}</span>
+		<a href="https://mauss.dev">Ignatius Bagus.</a>
+	</p>
+</footer>
+
+<style>
+	footer {
+		width: 100%;
+		max-width: 84ch;
+		position: relative;
+		display: grid;
+		gap: 0.5rem;
+		padding: 2rem;
+		padding-bottom: 3rem;
+		margin: 0 auto;
+
+		text-align: center;
+		font-family: var(--font-monospace);
+		font-size: 0.875rem;
+
+		p {
+			display: grid;
+			gap: 0.5rem;
+			grid-auto-flow: column;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+</style>

--- a/workspace/website/src/routes/Header.svelte
+++ b/workspace/website/src/routes/Header.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { page } from '$app/state';
+</script>
+
+<header>
+	<h1>{page.data.title}</h1>
+	<p>
+		<a href="https://github.com/ignatiusmb/aubade">Aubade</a>
+		<span>•</span>
+		<span>filesystem-based content processor</span>
+	</p>
+</header>
+
+<style>
+	header {
+		max-width: 80rem;
+		width: 100%;
+		display: grid;
+		gap: 0.875rem;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem 2rem 0;
+		margin: 0 auto;
+		font-size: 1.25rem;
+		text-align: center;
+
+		@media only screen and (min-width: 769px) {
+			justify-content: start;
+			padding: 2rem 1rem 0;
+			text-align: left;
+		}
+
+		h1 {
+			font-size: 4rem;
+		}
+	}
+</style>

--- a/workspace/website/src/routes/docs/+layout.svelte
+++ b/workspace/website/src/routes/docs/+layout.svelte
@@ -1,57 +1,24 @@
 <script lang="ts">
 	import { hydrate } from 'aubade/browser';
-	import { navigating, page } from '$app/state';
-
+	import { navigating } from '$app/state';
 	let { children } = $props();
 </script>
 
-<header>
-	<h1>{page.data.title}</h1>
-	<p>
-		<a href="https://github.com/ignatiusmb/aubade">Aubade</a>
-		<span>•</span>
-		<span>Data Authoring Framework</span>
-	</p>
-</header>
-
-<main use:hydrate={navigating.from}>
+<div {@attach hydrate(navigating.from)}>
 	{@render children()}
-</main>
+</div>
 
 <style>
-	header {
-		max-width: 80rem;
-		width: 100%;
-		display: grid;
-		gap: 0.875rem;
-		align-items: center;
-		justify-content: center;
-		padding: 2rem 2rem 0;
-		margin: 0 auto;
-		font-size: 1.25rem;
-		text-align: center;
-	}
-	h1 {
-		font-size: 4rem;
-	}
-
-	main {
+	div {
 		display: grid;
 		gap: 2rem;
 		grid-template-columns: minmax(0, 1fr);
 		align-items: flex-start;
 		justify-content: center;
 		padding: 0 2rem;
-		margin: 3rem auto;
-	}
+		margin: 3rem auto 0;
 
-	@media only screen and (min-width: 769px) {
-		header {
-			justify-content: start;
-			padding: 2rem 1rem 0;
-			text-align: left;
-		}
-		main {
+		@media only screen and (min-width: 769px) {
 			padding: 0 1rem;
 			grid-template-columns: minmax(12rem, 16rem) minmax(0, 60rem);
 		}

--- a/workspace/website/src/routes/docs/[slug]/+page.svelte
+++ b/workspace/website/src/routes/docs/[slug]/+page.svelte
@@ -117,7 +117,7 @@
 			border-radius: 50%;
 			margin-left: 0.25rem;
 			box-shadow: 0 0 0 0.25rem rgba(0, 112, 187, 0.6);
-			background: var(--mrq-primary);
+			background: var(--aubade-primary);
 		}
 		> h2::after,
 		> h3::after {
@@ -138,10 +138,10 @@
 		> blockquote {
 			padding: 1rem;
 			margin: 1rem 0;
-			border-left: 0.25rem solid var(--mrq-primary);
+			border-left: 0.25rem solid var(--aubade-primary);
 			background: rgba(0, 112, 187, 0.1);
 		}
-		.mrq[data-mrq='block'] {
+		[data-aubade='block'] {
 			margin: 1rem 0 1.5rem;
 		}
 	}

--- a/workspace/website/src/routes/docs/[slug]/Flank.svelte
+++ b/workspace/website/src/routes/docs/[slug]/Flank.svelte
@@ -11,14 +11,14 @@
 {#if flank}
 	<div>
 		{#if flank.back}
-			<a href={flank.back.slug}>
+			<a href={flank.back.slug} style:padding-right="1rem">
 				<span class="chevron">&lsaquo;</span>
 				<small>Previous</small>
 				<span class="title">{flank.back.title}</span>
 			</a>
 		{/if}
 		{#if flank.next}
-			<a href={flank.next.slug} style:margin-left="auto">
+			<a href={flank.next.slug} style:padding-left="1rem" style:margin-left="auto">
 				<span class="chevron" style:grid-column="2">&rsaquo;</span>
 				<small style:text-align="right">Next</small>
 				<span class="title">{flank.next.title}</span>
@@ -39,6 +39,13 @@
 		grid-template-columns: auto auto;
 		grid-template-rows: auto auto;
 		align-items: center;
+		padding: 0.5rem;
+		border-radius: var(--aubade-rounding);
+
+		&:focus-within,
+		&:hover {
+			background: var(--stone-700);
+		}
 
 		.chevron {
 			grid-row: 1 / -1;


### PR DESCRIPTION
some breaking changes included
- renamed `data-mrq*` to `data-aubade*`
- removed `mrq` from the `class`, no more `.mrq`
- removed `listen` in `/browser` module
- repurposed `hydrate` to return a svelte attachment