### PR TITLE
fix: disallow intraword `_` emphasis

### DIFF
--- a/workspace/aubade/src/artisan/markdown/example.spec.ts
+++ b/workspace/aubade/src/artisan/markdown/example.spec.ts
@@ -199,6 +199,31 @@ okay.`).html(),
 		expect(marker('*(*foo*)*').html()).toBe('<p><em>(<em>foo</em>)</em></p>');
 	});
 
+	it('#370', ({ expect }) => {
+		// https://spec.commonmark.org/0.31.2/#example-370
+		expect(marker('*foo*bar').html()).toBe('<p><em>foo</em>bar</p>');
+	});
+
+	it('#371', ({ expect }) => {
+		// https://spec.commonmark.org/0.31.2/#example-371
+		expect(marker('_foo bar _').html()).toBe('<p>_foo bar _</p>');
+	});
+
+	it('#372', ({ expect }) => {
+		// https://spec.commonmark.org/0.31.2/#example-372
+		expect(marker('_(_foo)').html()).toBe('<p>_(_foo)</p>');
+	});
+
+	it('#373', ({ expect }) => {
+		// https://spec.commonmark.org/0.31.2/#example-373
+		expect(marker('_(_foo_)_').html()).toBe('<p><em>(<em>foo</em>)</em></p>');
+	});
+
+	it('#374', ({ expect }) => {
+		// https://spec.commonmark.org/0.31.2/#example-374
+		expect(marker('_foo_bar').html()).toBe('<p>_foo_bar</p>');
+	});
+
 	it('#379', ({ expect }) => {
 		// https://spec.commonmark.org/0.31.2/#example-379
 		expect(marker('** foo bar**').html()).toBe('<p>** foo bar**</p>');

--- a/workspace/aubade/src/artisan/markdown/registry/modifier.ts
+++ b/workspace/aubade/src/artisan/markdown/registry/modifier.ts
@@ -20,6 +20,8 @@ export function emphasis({ cursor, is, annotate }: Context): null | {
 	const body = cursor.consume(char, (i) => {
 		const before = cursor.see(i - cursor.index - 1);
 		const after = cursor.see(i - cursor.index + 1);
+		// https://spec.commonmark.org/0.31.2/#example-374
+		if (char === '_' && is.alphanumeric(before) && is.alphanumeric(after)) return false;
 		return is['right-flanking'](before, after);
 	});
 	const invalid = body.includes('`') && cursor.peek(/`/);


### PR DESCRIPTION
i'm starting to like the spec a bit more